### PR TITLE
Python 3 compatibility, whitespace fix, setup.py requirements

### DIFF
--- a/pyping/__init__.py
+++ b/pyping/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from core import *
+from .core import *

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
 	author_email="geoffrey@lehee.name",
 	url='https://github.com/socketubs/Pyping/',
 	keywords="ping icmp network latency",
-	packages = ['pyping'],
+	packages=['pyping'],
+	install_requires=['six', 'clint'],
 	scripts=["bin/pyping"]
 )


### PR DESCRIPTION
- Python 3 compatibility using the six module - fix all
  raise and except statements
- Fix mixed tabs/space in line 185
- Fix some mixed newlines
- Add six and clint to install_requires in setup.py
